### PR TITLE
Feature/authentication user bearer

### DIFF
--- a/src/middlewares/auth-middleware.ts
+++ b/src/middlewares/auth-middleware.ts
@@ -1,0 +1,29 @@
+import type { Request, Response, NextFunction } from 'express';
+import { AuthError } from '../types/errors';
+import { verifyToken } from '../utils/jwt';
+
+interface AuthenticatedRequest extends Request {
+  user?: unknown;
+}
+
+export function authenticateJWT(req: Request, res: Response, next: NextFunction) {
+  const authHeader = req.header('Authorization');
+  if (!authHeader) {
+    return next(new AuthError('Authorization header missing', 'AUTH_MISSING_HEADER'));
+  }
+
+  const [type, token] = authHeader.split(' ');
+  if (type !== 'Bearer' || !token) {
+    return next(new AuthError('Invalid Authorization header format. Expected Bearer token.', 'AUTH_INVALID_FORMAT'));
+  }
+
+  try {
+    const payload = verifyToken(token);
+    if (typeof payload !== 'object' || !payload || !('id' in payload)) {
+      return next(new AuthError('Invalid token payload.', 'AUTH_INVALID_PAYLOAD'));
+    }
+    next();
+  } catch (err: unknown) {
+    return next(new AuthError('Invalid or expired token.', 'AUTH_INVALID_TOKEN'));
+  }
+}

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -4,13 +4,13 @@ import type { Request, Response } from 'express';
 import { prisma } from '../db';
 import type { UserDTO } from '../types/user';
 import { validateBody } from '../utils/validation';
+import { authenticateJWT } from '../middlewares/auth-middleware';
 
 const SALT_ROUNDS = 10;
 const userRouter = Router();
 
-userRouter.post('/', async (req: Request, res: Response) => {
+userRouter.post('/', authenticateJWT, async (req: Request, res: Response) => {
   await validateBody(req.body);
-
   const userInput = req.body as UserDTO;
 
   const hashedPassword = await bcrypt.hash(userInput.password, SALT_ROUNDS);

--- a/test/auth.ts
+++ b/test/auth.ts
@@ -9,7 +9,7 @@ import { generateToken } from '../src/utils/jwt';
 const PORT = process.env.PORT || 3001;
 const BASE_URL = `http://localhost:${PORT}`;
 
-describe.only('POST /auth', () => {
+describe('POST /auth', () => {
   const userData = {
     name: 'Test User',
     email: 'testuser@example.com',

--- a/test/auth.ts
+++ b/test/auth.ts
@@ -80,7 +80,6 @@ describe.only('POST /auth', () => {
       },
       { validateStatus: status => status === 401 },
     );
-    expect(response.status).to.equal(401);
     expect(response.data).to.deep.equal({
       error: 'AuthError',
       code: 'AUTH_02',
@@ -95,7 +94,12 @@ describe.only('POST /auth', () => {
       { email: userData.email },
       { validateStatus: status => status === 400 },
     );
-    expect(response.data).to.deep.equal({ error: 'ValidationError', code: 'AUTH_VALIDATION', details: 'Invalid credentials input', message: 'Erro na validação: algum campo da requisição não é válido.' });
+    expect(response.data).to.deep.equal({
+      error: 'ValidationError',
+      code: 'AUTH_VALIDATION',
+      details: 'Invalid credentials input',
+      message: 'Erro na validação: algum campo da requisição não é válido.',
+    });
   });
 
   it('should authenticate with rememberMe and return a token with 1 week expiration', async () => {

--- a/test/user.ts
+++ b/test/user.ts
@@ -53,13 +53,15 @@ describe('POST /users', () => {
       email: 'noauth@mail.com',
       password: 'password123',
     };
-    try {
-      await axios.post(`${BASE_URL}/users`, userData);
-    } catch (error) {
-      expect(error.response.status).to.equal(401);
-      expect(error.response.data).to.include({ error: 'AuthError' });
-      expect(error.response.data.code).to.equal('AUTH_MISSING_HEADER');
-    }
+    const response = await axios.post(`${BASE_URL}/users`, userData, {
+      validateStatus: status => status === 401,
+    });
+    expect(response.data).to.deep.equal({
+      error: 'AuthError',
+      details: 'Authorization header missing',
+      code: 'AUTH_MISSING_HEADER',
+      message: 'Erro de autenticação: as credenciais fornecidas não são válidas.',
+    });
   });
 
   it('should fail if Authorization header is not Bearer', async () => {
@@ -68,15 +70,16 @@ describe('POST /users', () => {
       email: 'badauth@mail.com',
       password: 'password123',
     };
-    try {
-      await axios.post(`${BASE_URL}/users`, userData, {
-        headers: { Authorization: `Token ${jwtToken}` },
-      });
-    } catch (error) {
-      expect(error.response.status).to.equal(401);
-      expect(error.response.data).to.include({ error: 'AuthError' });
-      expect(error.response.data.code).to.equal('AUTH_INVALID_FORMAT');
-    }
+    const response = await axios.post(`${BASE_URL}/users`, userData, {
+      headers: { Authorization: `Token ${jwtToken}` },
+      validateStatus: status => status === 401,
+    });
+    expect(response.data).to.deep.equal({
+      error: 'AuthError',
+      details: 'Invalid Authorization header format. Expected Bearer token.',
+      code: 'AUTH_INVALID_FORMAT',
+      message: 'Erro de autenticação: as credenciais fornecidas não são válidas.',
+    });
   });
 
   it('should fail if Authorization token is invalid', async () => {
@@ -87,15 +90,16 @@ describe('POST /users', () => {
     };
 
     const fakeToken = jwt.sign({ id: 0 }, 'wrong_secret', { expiresIn: '1h' });
-    try {
-      await axios.post(`${BASE_URL}/users`, userData, {
-        headers: { Authorization: `Bearer ${fakeToken}` },
-      });
-    } catch (error) {
-      expect(error.response.status).to.equal(401);
-      expect(error.response.data).to.include({ error: 'AuthError' });
-      expect(error.response.data.code).to.equal('AUTH_INVALID_TOKEN');
-    }
+    const response = await axios.post(`${BASE_URL}/users`, userData, {
+      headers: { Authorization: `Bearer ${fakeToken}` },
+      validateStatus: status => status === 401,
+    });
+    expect(response.data).to.deep.equal({
+      error: 'AuthError',
+      "details": "Invalid or expired token.",
+      code: 'AUTH_INVALID_TOKEN',
+      message: 'Erro de autenticação: as credenciais fornecidas não são válidas.',
+    });
   });
 
   describe('Validation', () => {

--- a/test/user.ts
+++ b/test/user.ts
@@ -1,14 +1,24 @@
 import axios from 'axios';
 import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
+import { describe, it, beforeEach } from 'mocha';
 import { prisma } from '../src/db';
+import { generateToken } from '../src/utils/jwt';
 
 const PORT = process.env.PORT || 3001;
 const BASE_URL = `http://localhost:${PORT}`;
 
+// let jwtToken: string;
+
+// beforeEach(async () => {
+//   jwtToken = generateToken({ id: 0 });
+// });
+
+const jwtToken = generateToken({ id: 0 });
+
 describe('POST /users', () => {
-  it('should create a new user', async () => {
+  it('should create a new user when authenticated', async () => {
     const userData = {
       name: 'Test User',
       email: 'Test.User@Mail.com',
@@ -17,13 +27,17 @@ describe('POST /users', () => {
     };
     const { password: plainPassword, ...userDataWithoutPassword } = userData;
 
-    const response = await axios.post(`${BASE_URL}/users`, userData);
+    const response = await axios.post(`${BASE_URL}/users`, userData, {
+      headers: { Authorization: `Bearer ${jwtToken}` },
+    });
 
     const createdUser = await prisma.user.findUnique({
       where: { email: userData.email },
     });
+
     expect(createdUser).to.not.be.null;
-    const { id, password, ...userColumns } = createdUser!;
+    if (!createdUser) throw new Error('User was not created');
+    const { id, password, ...userColumns } = createdUser;
     expect(id).to.be.gt(0);
     expect(userColumns).to.deep.equal({
       ...userDataWithoutPassword,
@@ -39,16 +53,98 @@ describe('POST /users', () => {
     });
   });
 
-  it('should fail if body is missing', async () => {
-    const response = await axios.post(`${BASE_URL}/users`, undefined, {
-      validateStatus: (status) => status === 400,
+  it('should fail if Authorization header is missing', async () => {
+    const userData = {
+      name: 'No Auth',
+      email: 'noauth@mail.com',
+      password: 'password123',
+    };
+    try {
+      await axios.post(`${BASE_URL}/users`, userData);
+    } catch (error) {
+      expect(error.response.status).to.equal(401);
+      expect(error.response.data).to.include({ error: 'AuthError' });
+      expect(error.response.data.code).to.equal('AUTH_MISSING_HEADER');
+    }
+  });
+
+  it('should fail if Authorization header is not Bearer', async () => {
+    const userData = {
+      name: 'Bad Auth',
+      email: 'badauth@mail.com',
+      password: 'password123',
+    };
+    try {
+      await axios.post(`${BASE_URL}/users`, userData, {
+        headers: { Authorization: `Token ${jwtToken}` },
+      });
+    } catch (error) {
+      expect(error.response.status).to.equal(401);
+      expect(error.response.data).to.include({ error: 'AuthError' });
+      expect(error.response.data.code).to.equal('AUTH_INVALID_FORMAT');
+    }
+  });
+
+  it('should fail if Authorization token is invalid', async () => {
+    const userData = {
+      name: 'Invalid Token',
+      email: 'invalidtoken@mail.com',
+      password: 'password123',
+    };
+
+    const fakeToken = jwt.sign({ id: 0 }, 'wrong_secret', { expiresIn: '1h' });
+    try {
+      await axios.post(`${BASE_URL}/users`, userData, {
+        headers: { Authorization: `Bearer ${fakeToken}` },
+      });
+    } catch (error) {
+      expect(error.response.status).to.equal(401);
+      expect(error.response.data).to.include({ error: 'AuthError' });
+      expect(error.response.data.code).to.equal('AUTH_INVALID_TOKEN');
+    }
+  });
+
+  describe('Validation', () => {
+    it('should fail if body is missing', async () => {
+      try {
+        await axios.post(`${BASE_URL}/users`, undefined, {
+          headers: { Authorization: `Bearer ${jwtToken}` },
+        });
+      } catch (error) {
+        expect(error.response.status).to.equal(400);
+        expect(error.response.data).to.include({
+          error: 'ValidationError',
+          code: 'USR_01',
+        });
+        expect(error.response.data.message).to.be.a('string');
+        expect(error.response.data.details).to.equal('Request body is required.');
+      }
     });
-    expect(response.status).to.equal(400);
-    expect(response.data).to.deep.equal({
-      error: 'ValidationError',
-      code: 'USR_01',
-      message: 'Erro na validação: algum campo da requisição não é válido.',
-      details: 'Request body is required.',
+
+    it('should fail if required fields are missing', async () => {
+      const invalidBodies = [
+        {},
+        { name: 'Test' },
+        { email: 'test@mail.com' },
+        { password: 'abc123' },
+        { name: 'Test', email: 'test@mail.com' },
+        { name: 'Test', password: 'abc123' },
+        { email: 'test@mail.com', password: 'abc123' },
+      ];
+      for (const body of invalidBodies) {
+        try {
+          await axios.post(`${BASE_URL}/users`, body, {
+            headers: { Authorization: `Bearer ${jwtToken}` },
+          });
+        } catch (error) {
+          expect(error.response.status).to.equal(400);
+          expect(error.response.data).to.include({
+            error: 'ValidationError',
+            code: 'USR_02',
+          });
+          expect(error.response.data.details).to.equal('Email, name, and password are required.');
+        }
+      }
     });
   });
 

--- a/test/user.ts
+++ b/test/user.ts
@@ -2,18 +2,12 @@ import axios from 'axios';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
+import { describe, it } from 'mocha';
 import { prisma } from '../src/db';
 import { generateToken } from '../src/utils/jwt';
 
 const PORT = process.env.PORT || 3001;
 const BASE_URL = `http://localhost:${PORT}`;
-
-// let jwtToken: string;
-
-// beforeEach(async () => {
-//   jwtToken = generateToken({ id: 0 });
-// });
 
 const jwtToken = generateToken({ id: 0 });
 
@@ -106,19 +100,16 @@ describe('POST /users', () => {
 
   describe('Validation', () => {
     it('should fail if body is missing', async () => {
-      try {
-        await axios.post(`${BASE_URL}/users`, undefined, {
-          headers: { Authorization: `Bearer ${jwtToken}` },
-        });
-      } catch (error) {
-        expect(error.response.status).to.equal(400);
-        expect(error.response.data).to.include({
-          error: 'ValidationError',
-          code: 'USR_01',
-        });
-        expect(error.response.data.message).to.be.a('string');
-        expect(error.response.data.details).to.equal('Request body is required.');
-      }
+      const response = await axios.post(`${BASE_URL}/users`, undefined, {
+        headers: { Authorization: `Bearer ${jwtToken}` },
+        validateStatus: status => status === 400,
+      });
+      expect(response.data).to.deep.equal({
+        error: 'ValidationError',
+        code: 'USR_01',
+        message: 'Erro na validação: algum campo da requisição não é válido.',
+        details: 'Request body is required.',
+      });
     });
 
     it('should fail if required fields are missing', async () => {
@@ -132,57 +123,35 @@ describe('POST /users', () => {
         { email: 'test@mail.com', password: 'abc123' },
       ];
       for (const body of invalidBodies) {
-        try {
-          await axios.post(`${BASE_URL}/users`, body, {
-            headers: { Authorization: `Bearer ${jwtToken}` },
-          });
-        } catch (error) {
-          expect(error.response.status).to.equal(400);
-          expect(error.response.data).to.include({
-            error: 'ValidationError',
-            code: 'USR_02',
-          });
-          expect(error.response.data.details).to.equal('Email, name, and password are required.');
-        }
+        const response = await axios.post(`${BASE_URL}/users`, body, {
+          headers: { Authorization: `Bearer ${jwtToken}` },
+          validateStatus: status => status === 400,
+        });
+        expect(response.data).to.deep.equal({
+          error: 'ValidationError',
+          code: 'USR_02',
+          message: 'Erro na validação: algum campo da requisição não é válido.',
+          details: 'Email, name, and password are required.',
+        });
       }
     });
-  });
-
-  it('should fail if required fields are missing', async () => {
-    const invalidBodies = [
-      {},
-      { name: 'Test' },
-      { email: 'test@mail.com' },
-      { password: 'abc123' },
-      { name: 'Test', email: 'test@mail.com' },
-      { name: 'Test', password: 'abc123' },
-      { email: 'test@mail.com', password: 'abc123' },
-    ];
-    for (const body of invalidBodies) {
-      const response = await axios.post(`${BASE_URL}/users`, body, {
-        validateStatus: (status) => status === 400,
-      });
-      expect(response.status).to.equal(400);
-      expect(response.data).to.deep.equal({
-        error: 'ValidationError',
-        code: 'USR_02',
-        message: 'Erro na validação: algum campo da requisição não é válido.',
-        details: 'Email, name, and password are required.',
-      });
-    }
   });
 
   it('should fail if password is too short or lacks digits/letters', async () => {
     const invalidPasswords = ['abc', '123456', 'abcdef', 'abc12'];
     for (const password of invalidPasswords) {
-      const response = await axios.post(`${BASE_URL}/users`, {
-        name: 'Test',
-        email: `test${password}@mail.com`,
-        password,
-      }, {
-        validateStatus: (status) => status === 400,
-      });
-      expect(response.status).to.equal(400);
+      const response = await axios.post(
+        `${BASE_URL}/users`,
+        {
+          name: 'Test',
+          email: `test${password}@mail.com`,
+          password,
+        },
+        {
+          headers: { Authorization: `Bearer ${jwtToken}` },
+          validateStatus: status => status === 400,
+        },
+      );
       expect(response.data).to.deep.equal({
         error: 'ValidationError',
         code: 'USR_03',
@@ -193,15 +162,19 @@ describe('POST /users', () => {
   });
 
   it('should fail if birthdate is invalid', async () => {
-    const response = await axios.post(`${BASE_URL}/users`, {
-      name: 'Test',
-      email: 'testbirthdate@mail.com',
-      password: 'abc123',
-      birthdate: 'not-a-date',
-    }, {
-      validateStatus: (status) => status === 400,
-    });
-    expect(response.status).to.equal(400);
+    const response = await axios.post(
+      `${BASE_URL}/users`,
+      {
+        name: 'Test',
+        email: 'testbirthdate@mail.com',
+        password: 'abc123',
+        birthdate: 'not-a-date',
+      },
+      {
+        headers: { Authorization: `Bearer ${jwtToken}` },
+        validateStatus: status => status === 400,
+      },
+    );
     expect(response.data).to.deep.equal({
       error: 'ValidationError',
       code: 'USR_04',
@@ -224,9 +197,9 @@ describe('POST /users', () => {
       },
     });
     const response = await axios.post(`${BASE_URL}/users`, user, {
-      validateStatus: (status) => status === 409,
+      headers: { Authorization: `Bearer ${jwtToken}` },
+      validateStatus: status => status === 409,
     });
-    expect(response.status).to.equal(409);
     expect(response.data).to.deep.equal({
       error: 'ConflictError',
       code: 'USR_05',


### PR DESCRIPTION
This pull request introduces authentication middleware for JWT-based authorization and updates the user creation flow to require authentication. It also includes new test cases to ensure proper validation and error handling for authentication and user input.

### Authentication Middleware and Integration:
* Added `authenticateJWT` middleware in `src/middlewares/auth-middleware.ts` to validate JWT tokens and handle authorization errors.
* Integrated `authenticateJWT` middleware into the `POST /users` endpoint in `src/routes/user.ts`, requiring valid authorization for user creation.

### Error Handling Improvements:
* Removed unnecessary `Object.setPrototypeOf` call in the `AuthError` class in `src/types/errors.ts` for cleaner error handling.

### Testing Enhancements:
* Updated `test/user.ts` to include tests for the new authentication flow:
  - Ensures user creation fails without an `Authorization` header or with invalid tokens.
  - Validates proper error responses for missing or malformed headers and invalid tokens. [[1]](diffhunk://#diff-bfadcf9810ed2fce88151932ee63e9126969140abeb2cd021e3a6741bdcfed03L20-R40) [[2]](diffhunk://#diff-bfadcf9810ed2fce88151932ee63e9126969140abeb2cd021e3a6741bdcfed03R56-R147)
* Modified existing tests to include JWT tokens in `Authorization` headers for authenticated requests.
* Removed the `.only` modifier from a test in `test/auth.ts` to ensure all tests run.